### PR TITLE
makefile攏換做tab

### DIFF
--- a/HLMTools/Makefile.in
+++ b/HLMTools/Makefile.in
@@ -74,6 +74,6 @@ install: mkinstalldir $(PROGS)
 	for program in $(PROGS) ; do $(INSTALL) -m 755 $${program}@BINARY_EXTENSION@ $(bindir) ; done
 
 mkinstalldir:
-        if [ ! -d $(bindir) -a X_@TRADHTK@ = X_yes ] ; then mkdir -p $(bindir) ; fi
+	if [ ! -d $(bindir) -a X_@TRADHTK@ = X_yes ] ; then mkdir -p $(bindir) ; fi
 
 .PHONY: all strip clean cleanup distclean install mkinstalldir


### PR DESCRIPTION
```
錯誤資訊：Makefile:77: *** missing separator (did you mean TAB instead of 8 spa.
make: *** [hlmtools] Error 1
```